### PR TITLE
enforce esqlite dep min version for otp 27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "25.2"
-          gleam-version: "0.32.2"
+          gleam-version: "1.1.0"
           rebar3-version: "3"
       - uses: denoland/setup-deno@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.ez
 build
 erl_crash.dump
+
+/tmp/
+!/tmp/.keep
+
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.0 - 2024-05-22
+
+- Updated esqlite dependency to work with erlang/otp 27.0.
+- Require gleam >= 1.0.0.
+- Updated for gleam 1.1.0.
+
 ## v0.9.0 - 2023-11-06
 
 - Updated for v0.32.0.
@@ -23,7 +29,7 @@
 
 ## v0.5.0 - 2023-01-08
 
-- This library now works on JavaScript with the Deno runtime. 
+- This library now works on JavaScript with the Deno runtime.
 - The `status` function has been removed.
 
 ## v0.4.0 - 2023-01-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v0.10.0 - 2024-05-22
 
-- Updated esqlite dependency to work with erlang/otp 27.0.
-- Require gleam >= 1.0.0.
-- Updated for gleam 1.1.0.
+- Raised esqlite dependency minimum version
+  to work with Erlang/OTP 27.0.
+- Require Gleam >= 1.0.0.
 
 ## v0.9.0 - 2023-11-06
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -21,7 +21,7 @@ allow_write = ["tmp"]
 [dependencies]
 gleam_stdlib = ">= 0.37.0 and < 2.0.0"
 pc = ">= 1.15.0 and < 2.0.0"
-esqlite = ">= 0.8.8 and < 2.0.0"
+esqlite = ">= 0.8.8 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.1.2 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,9 +1,9 @@
 name = "sqlight"
-version = "0.9.0"
+version = "0.10.0"
 licences = ["Apache-2.0"]
 description = "Use SQLite from Gleam!"
 
-gleam = ">= 0.32.0"
+gleam = ">= 1.0.0"
 
 repository = { type = "github", user = "lpil", repo = "sqlight" }
 links = [
@@ -26,8 +26,8 @@ allow_write = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.25"
-esqlite = "~> 0.8"
+gleam_stdlib = ">= 0.37.0 and < 2.0.0"
+esqlite = ">= 0.8.8 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.1.2 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -7,26 +7,20 @@ gleam = ">= 1.0.0"
 
 repository = { type = "github", user = "lpil", repo = "sqlight" }
 links = [
-  { title = "Website", href = "https://gleam.run" },
-  { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
+    { title = "Website", href = "https://gleam.run" },
+    { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
 
 [javascript]
 runtime = "deno"
 
 [javascript.deno]
-allow_read = [
-  "gleam.toml",
-  "test",
-  "build",
-  "tmp",
-]
-allow_write = [
-  "tmp",
-]
+allow_read = ["gleam.toml", "test", "build", "tmp"]
+allow_write = ["tmp"]
 
 [dependencies]
 gleam_stdlib = ">= 0.37.0 and < 2.0.0"
+pc = ">= 1.15.0 and < 2.0.0"
 esqlite = ">= 0.8.8 and < 2.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "esqlite", version = "0.8.6", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "607E45F4DA42601D8F530979417F57A4CD629AB49085891849302057E68EA188" },
-  { name = "gleam_stdlib", version = "0.32.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "07D64C26D014CF570F8ACADCE602761EA2E74C842D26F2FD49B0D61973D9966F" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
+  { name = "esqlite", version = "0.8.7", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "AF89C66027704B681657FDCCFFCEAA238D0DD702D5F687CDA3037F1D599A7551" },
+  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
+  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
 ]
 
 [requirements]
-esqlite = { version = "~> 0.8" }
-gleam_stdlib = { version = "~> 0.25" }
-gleeunit = { version = "~> 1.0" }
+esqlite = { version = ">= 0.8.7 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.37.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.1.2 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "esqlite", version = "0.8.7", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "AF89C66027704B681657FDCCFFCEAA238D0DD702D5F687CDA3037F1D599A7551" },
+  { name = "esqlite", version = "0.8.8", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "374902457C7D94DC9409C98D3BDD1CA0D50A60DC9F3BDF1FD8EB74C0DCDF02D6" },
   { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "pc", version = "1.15.0", build_tools = ["rebar3"], requirements = [], otp_app = "pc", source = "hex", outer_checksum = "4C0FAD4F6437CAE353D517DA218FE78347B8FFA44B9817887494CAAAE54595B3" },
 ]
 
 [requirements]
-esqlite = { version = ">= 0.8.7 and < 2.0.0" }
+esqlite = { version = ">= 0.8.8 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.37.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.1.2 and < 2.0.0" }
+pc = { version = ">= 1.15.0 and < 2.0.0" }

--- a/src/sqlight.gleam
+++ b/src/sqlight.gleam
@@ -1,8 +1,8 @@
-import gleam/list
-import gleam/string
-import gleam/result
-import gleam/option.{type Option, None, Some}
 import gleam/dynamic.{type Decoder, type Dynamic}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
 
 pub type Connection
 
@@ -482,6 +482,11 @@ fn decode_error(errors: List(dynamic.DecodeError)) -> Error {
   let assert [dynamic.DecodeError(expected, actual, path), ..] = errors
   let path = string.join(path, ".")
   let message =
-    "Decoder failed, expected " <> expected <> ", got " <> actual <> " in " <> path
+    "Decoder failed, expected "
+    <> expected
+    <> ", got "
+    <> actual
+    <> " in "
+    <> path
   SqlightError(code: GenericError, message: message, offset: -1)
 }

--- a/test/sqlight_test.gleam
+++ b/test/sqlight_test.gleam
@@ -1,9 +1,9 @@
-import sqlight.{SqlightError}
+import gleam/dynamic
+import gleam/list
+import gleam/option
 import gleeunit
 import gleeunit/should
-import gleam/dynamic
-import gleam/option
-import gleam/list
+import sqlight.{SqlightError}
 
 pub fn main() {
   gleeunit.main()


### PR DESCRIPTION
- requires that esqlite updates to >= 0.8.8
- which needs to update to pc ~> 1.15 see https://github.com/blt/port_compiler/commit/7902cbeefaf18ce59878330b0f7bd946cc6ed963

I got in touch with esqlite but the author seems to not have the most recent version on github yet.