### PR TITLE
Bind `sqlight.blob()` output as a BLOB instead of TEXT

### DIFF
--- a/src/sqlight.gleam
+++ b/src/sqlight.gleam
@@ -439,13 +439,9 @@ pub fn text(value: String) -> Value {
 /// Convert a Gleam `BitString` to an SQLite blob, to be used an argument to a
 /// query.
 ///
-pub fn blob(value: BitArray) -> Value {
-  coerce_blob(value)
-}
-
 @external(erlang, "sqlight_ffi", "coerce_blob")
 @external(javascript, "./sqlight_ffi.js", "coerce_blob")
-fn coerce_blob(a: BitArray) -> Value
+pub fn blob(value: BitArray) -> Value
 
 /// Convert a Gleam `Bool` to an SQLite int, to be used an argument to a
 /// query.

--- a/src/sqlight.gleam
+++ b/src/sqlight.gleam
@@ -443,7 +443,7 @@ pub fn blob(value: BitArray) -> Value {
   coerce_blob(value)
 }
 
-@external(erlang, "sqlight_ffi", "coerce_value")
+@external(erlang, "sqlight_ffi", "coerce_blob")
 @external(javascript, "./sqlight_ffi.js", "coerce_blob")
 fn coerce_blob(a: BitArray) -> Value
 

--- a/src/sqlight_ffi.erl
+++ b/src/sqlight_ffi.erl
@@ -1,7 +1,7 @@
 -module(sqlight_ffi).
 
 -export([
-    status/0, query/3, exec/2, coerce_value/1, null/0, open/1, close/1
+    status/0, query/3, exec/2, coerce_value/1, coerce_blob/1, null/0, open/1, close/1
 ]).
 
 open(Name) ->
@@ -54,6 +54,7 @@ status() ->
     }.
 
 coerce_value(X) -> X.
+coerce_blob(Bin) -> {blob, Bin}.
 null() -> undefined.
 
 to_error(Connection = {esqlite3, _}, Code) when is_integer(Code) ->

--- a/test/sqlight_test.gleam
+++ b/test/sqlight_test.gleam
@@ -106,12 +106,12 @@ pub fn bind_text_test() {
 @target(erlang)
 pub fn bind_blob_test() {
   use conn <- connect()
-  let assert Ok([<<123, 0>>]) =
+  let assert Ok([#(<<123, 0>>, "blob")]) =
     sqlight.query(
-      "select ?",
+      "select ?1, typeof(?1)",
       conn,
       [sqlight.blob(<<123, 0>>)],
-      dynamic.element(0, dynamic.bit_array),
+      dynamic.tuple2(dynamic.bit_array, dynamic.string),
     )
 }
 


### PR DESCRIPTION
This makes use of explicit type binds in esqlite3 since `String` & `BitArray` use the same runtime representation. This avoids an ambiguity [here](https://github.com/mmzeeman/esqlite/blob/58454af87559981aed6fb1235fc3f63d618505db/src/esqlite3.erl#L360-L361).
