### PR TITLE
Add support for prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.10.0 - 2024-11-21
+
+- Added support for prepared statements. They can be created with `prepare` and 
+  queried with `query_prepared`.
+
 ## v0.9.1 - 2024-08-19
 
 - Fixed a bug where bit arrays could bind to the incorrect SQLite type.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ pub fn main() {
   "
   let assert Ok([#("Nubi", 4), #("Ginny", 6)]) =
     sqlight.query(sql, on: conn, with: [sqlight.int(7)], expecting: cat_decoder)
+
+  let assert Ok(prepared) =
+    sqlight.prepare(sql, on: conn, expecting: cat_decoder)
+  let assert Ok([#("Nubi", 4), #("Ginny", 6)]) =
+    sqlight.query_prepared(prepared, with: [sqlight.int(7)])
 }
 ```
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlight"
-version = "0.9.1"
+version = "0.10.0"
 licences = ["Apache-2.0"]
 description = "Use SQLite from Gleam!"
 


### PR DESCRIPTION
Hello :)

I added support for prepared query statements to improve overall performance when queries are reused.  
Since both libraries (Erlang and JavaScript) use prepared statements under the hood when calling `query`, I split this function into `prepare` and `query_prepared`.

I also updated every test that uses `sqlight.query` by introducing a helper function that ensures both functions return the same errors and results.

I had to wrap the database connection in `sqlight_ffi.js` to keep track of the created prepared statements since the library requires that they be finalized before closing the connection. I think this isn't the most elegant solution, but I'm not aware of a better approach.

I also updated the `README` example, the `CHANGELOG`, and bumped the version to `0.10.0`.

Thank you very much for the great work, and I'm hoping I didn't miss anything this time. :)