### PR TITLE
Migrate to gleam/dynamic/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ gleam add sqlight
 ```
 
 ```gleam
-import gleam/dynamic
+import gleam/dynamic/decode
 import sqlight
 
 pub fn main() {
   use conn <- sqlight.with_connection(":memory:")
-  let cat_decoder = dynamic.tuple2(dynamic.string, dynamic.int)
+  let cat_decoder = {
+    use name <- decode.field(0, decode.string)
+    use age <- decode.field(1, decode.int)
+    decode.success(#(name, age))
+  }
 
   let sql = "
   create table cats (name text, age int);

--- a/gleam.toml
+++ b/gleam.toml
@@ -26,7 +26,7 @@ allow_write = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.25"
+gleam_stdlib = "~> 0.51"
 esqlite = "~> 0.8"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "esqlite", version = "0.8.8", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "374902457C7D94DC9409C98D3BDD1CA0D50A60DC9F3BDF1FD8EB74C0DCDF02D6" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "esqlite", version = "0.8.9", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "465AE9AE28AE4192EA54C829FDC90C320447D439A9B2E10946621672FC6A6F8C" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
 esqlite = { version = "~> 0.8" }
-gleam_stdlib = { version = "~> 0.25" }
+gleam_stdlib = { version = "~> 0.51" }
 gleeunit = { version = "~> 1.0" }


### PR DESCRIPTION
Looks like I started my first gleam project days after a new decoder API turned up. This worked for me for migrating sqlight to `gleam/dynamic/decode` from `gleam/dynamic`. I wouldn't be surprised if this is unidiomatic in some ways, i.e. if something different ought to be done w/ `sqlight.decode_bool`, but I did see the tests pass on both targets!